### PR TITLE
Update Travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ notifications:
   email:
     on_success: never
 
-install: gem install minitest culqi-ruby
-
 script: rake test
 
 sudo: false


### PR DESCRIPTION
I updated ruby to latests versions and removed install script.

If I'm not wrong, `minitest` comes with ruby since version 2. And `culqi-ruby` is loaded from `lib` directory so I don't think is necessary to install.